### PR TITLE
feat: add custom-data support for cases and items

### DIFF
--- a/addons/DCWebHook/src/main/java/com/jodexindustries/dcwebhook/config/DiscordWebhook.java
+++ b/addons/DCWebHook/src/main/java/com/jodexindustries/dcwebhook/config/DiscordWebhook.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 @ConfigSerializable
 public class DiscordWebhook {
@@ -105,7 +106,7 @@ public class DiscordWebhook {
         String group = winItem.group() != null ? winItem.group() : winItem.name();
         String caseType = activeCase.caseType();
 
-        return DCTools.rt(
+        text = DCTools.rt(
                 text,
                 Placeholder.of("%player%", player),
                 Placeholder.of("%group%", group),
@@ -119,6 +120,19 @@ public class DiscordWebhook {
                         mappings.cases.getOrDefault(caseType, caseType)
                 )
         );
+
+        // Replace custom-data placeholders: %case_data:<key>% and %item_data:<key>%
+        Map<String, Object> caseCustomData = activeCase.definition().settings().customData();
+        Map<String, Object> itemCustomData = winItem.customData();
+
+        for (Map.Entry<String, Object> entry : caseCustomData.entrySet()) {
+            text = text.replace("%case_data:" + entry.getKey() + "%", String.valueOf(entry.getValue()));
+        }
+        for (Map.Entry<String, Object> entry : itemCustomData.entrySet()) {
+            text = text.replace("%item_data:" + entry.getKey() + "%", String.valueOf(entry.getValue()));
+        }
+
+        return text;
     }
 
     private String readFully(InputStream inputStream) throws IOException {

--- a/addons/DCWebHook/src/main/resources/config.yml
+++ b/addons/DCWebHook/src/main/resources/config.yml
@@ -3,7 +3,7 @@ url: "" # here is your discord webhook
 #username: ""
 #avatar_url: ""
 #tts: false
-embeds: # Placeholders: %player%, %group%, %group_mapping%, %casetype%, %casetype_mapping%
+embeds: # Placeholders: %player%, %group%, %group_mapping%, %casetype%, %casetype_mapping%, %item_data:<key>%, %case_data:<key>%
   title: "DonateCase, opening case:"
 #  description: ""
   color: 444444

--- a/api/src/main/java/com/jodexindustries/donatecase/api/data/casedefinition/CaseItem.java
+++ b/api/src/main/java/com/jodexindustries/donatecase/api/data/casedefinition/CaseItem.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -35,7 +37,13 @@ public class CaseItem implements Cloneable {
 
     private Map<String, RandomAction> randomActions;
 
+    private Map<String, Object> customData;
+
     public CaseItem(String name, @Nullable String group, double chance, int index, CaseMaterial material, GiveType giveType, List<String> actions, List<String> alternativeActions, Map<String, RandomAction> randomActions) {
+        this(name, group, chance, index, material, giveType, actions, alternativeActions, randomActions, Collections.emptyMap());
+    }
+
+    public CaseItem(String name, @Nullable String group, double chance, int index, CaseMaterial material, GiveType giveType, List<String> actions, List<String> alternativeActions, Map<String, RandomAction> randomActions, Map<String, Object> customData) {
         this.name = name;
         this.group = group;
         this.chance = chance;
@@ -45,6 +53,7 @@ public class CaseItem implements Cloneable {
         this.actions = actions;
         this.alternativeActions = alternativeActions;
         this.randomActions = randomActions;
+        this.customData = customData != null ? customData : Collections.emptyMap();
     }
 
     public RandomAction getRandomAction() {

--- a/api/src/main/java/com/jodexindustries/donatecase/api/data/casedefinition/CaseSettings.java
+++ b/api/src/main/java/com/jodexindustries/donatecase/api/data/casedefinition/CaseSettings.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.spongepowered.configurate.ConfigurationNode;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +38,13 @@ public class CaseSettings implements Cloneable {
 
     private String displayName;
 
+    private Map<String, Object> customData;
+
     public CaseSettings(String type, String defaultMenu, String animation, Hologram hologram, LevelGroups levelGroups, List<String> noKeyActions, OpenType openType, ConfigurationNode animationSettings, int cooldownBeforeAnimation, int historyDataSize, String displayName) {
+        this(type, defaultMenu, animation, hologram, levelGroups, noKeyActions, openType, animationSettings, cooldownBeforeAnimation, historyDataSize, displayName, Collections.emptyMap());
+    }
+
+    public CaseSettings(String type, String defaultMenu, String animation, Hologram hologram, LevelGroups levelGroups, List<String> noKeyActions, OpenType openType, ConfigurationNode animationSettings, int cooldownBeforeAnimation, int historyDataSize, String displayName, Map<String, Object> customData) {
         this.type = type;
         this.defaultMenu = defaultMenu;
         this.animation = animation;
@@ -49,6 +56,7 @@ public class CaseSettings implements Cloneable {
         this.cooldownBeforeAnimation = cooldownBeforeAnimation;
         this.historyDataSize = historyDataSize;
         this.displayName = displayName;
+        this.customData = customData != null ? customData : Collections.emptyMap();
     }
 
     @Override

--- a/common/src/main/java/com/jodexindustries/donatecase/common/config/serializer/casedefinition/CaseItemSerializer.java
+++ b/common/src/main/java/com/jodexindustries/donatecase/common/config/serializer/casedefinition/CaseItemSerializer.java
@@ -9,6 +9,7 @@ import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +36,8 @@ public class CaseItemSerializer implements TypeSerializer<CaseItem> {
                 node.node("give-type").get(GiveType.class, GiveType.ONE),
                 node.node("actions").getList(String.class),
                 node.node("alternative-actions").getList(String.class),
-                randomActions
+                randomActions,
+                deserializeCustomData(node.node("custom-data"))
         );
     }
 
@@ -57,6 +59,26 @@ public class CaseItemSerializer implements TypeSerializer<CaseItem> {
             for (Map.Entry<String, CaseItem.RandomAction> entry : randomActions.entrySet()) {
                 randomActionsNode.node(entry.getKey()).set(CaseItem.RandomAction.class, entry.getValue());
             }
+        }
+
+        serializeCustomData(node.node("custom-data"), obj.customData());
+    }
+
+    static Map<String, Object> deserializeCustomData(ConfigurationNode node) {
+        if (node.virtual() || !node.isMap()) return Collections.emptyMap();
+
+        Map<String, Object> map = new HashMap<>();
+        for (Map.Entry<Object, ? extends ConfigurationNode> entry : node.childrenMap().entrySet()) {
+            map.put(String.valueOf(entry.getKey()), entry.getValue().raw());
+        }
+        return map;
+    }
+
+    static void serializeCustomData(ConfigurationNode node, Map<String, Object> customData) throws SerializationException {
+        if (customData == null || customData.isEmpty()) return;
+
+        for (Map.Entry<String, Object> entry : customData.entrySet()) {
+            node.node(entry.getKey()).raw(entry.getValue());
         }
     }
 

--- a/common/src/main/java/com/jodexindustries/donatecase/common/config/serializer/casedefinition/CaseSettingsSerializer.java
+++ b/common/src/main/java/com/jodexindustries/donatecase/common/config/serializer/casedefinition/CaseSettingsSerializer.java
@@ -33,7 +33,8 @@ public class CaseSettingsSerializer implements TypeSerializer<CaseSettings> {
                 node.node("animation-settings"),
                 node.node("cooldown-before-animation").getInt(),
                 node.node("history-data-size").getInt(),
-                node.node("display-name").getString()
+                node.node("display-name").getString(),
+                CaseItemSerializer.deserializeCustomData(node.node("custom-data"))
         );
     }
 
@@ -52,6 +53,8 @@ public class CaseSettingsSerializer implements TypeSerializer<CaseSettings> {
         node.node("cooldown-before-animation").set(obj.cooldownBeforeAnimation());
         node.node("history-data-size").set(obj.historyDataSize());
         node.node("display-name").set(obj.displayName());
+
+        CaseItemSerializer.serializeCustomData(node.node("custom-data"), obj.customData());
     }
 
     public static class LevelGroups implements TypeSerializer<CaseSettings.LevelGroups> {


### PR DESCRIPTION
Add Map<String, Object> custom-data field to CaseItem and CaseSettings, allowing addons to read arbitrary user-defined parameters from case configs.

DCWebHook now supports %item_data:<key>% and %case_data:<key>% placeholders, replacing the need for hardcoded mappings.