### PR TITLE
fix: clear stale GUI map entry on player quit and join

### DIFF
--- a/api/src/main/java/com/jodexindustries/donatecase/api/event/player/LeaveEvent.java
+++ b/api/src/main/java/com/jodexindustries/donatecase/api/event/player/LeaveEvent.java
@@ -1,0 +1,16 @@
+package com.jodexindustries.donatecase.api.event.player;
+
+import com.jodexindustries.donatecase.api.event.DCEvent;
+import com.jodexindustries.donatecase.api.platform.DCPlayer;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.NotNull;
+
+@EqualsAndHashCode(callSuper = true)
+@Accessors(fluent = true)
+@Data
+public class LeaveEvent extends DCEvent {
+
+    @NotNull private final DCPlayer player;
+}

--- a/common/src/main/java/com/jodexindustries/donatecase/common/event/EventListener.java
+++ b/common/src/main/java/com/jodexindustries/donatecase/common/event/EventListener.java
@@ -11,6 +11,7 @@ import com.jodexindustries.donatecase.api.data.storage.CaseInfo;
 import com.jodexindustries.donatecase.api.event.player.CaseInteractEvent;
 import com.jodexindustries.donatecase.api.event.player.GuiClickEvent;
 import com.jodexindustries.donatecase.api.event.player.JoinEvent;
+import com.jodexindustries.donatecase.api.event.player.LeaveEvent;
 import com.jodexindustries.donatecase.api.platform.DCPlayer;
 import com.jodexindustries.donatecase.api.tools.DCTools;
 import com.jodexindustries.donatecase.common.gui.items.OPENItemClickHandlerImpl;
@@ -33,6 +34,7 @@ public class EventListener implements Subscriber {
     @Subscribe
     public void onPlayerJoin(JoinEvent event) {
         DCPlayer player = event.player();
+        DCAPI.getInstance().getGUIManager().getMap().remove(player.getUniqueId());
         if (player.hasPermission("donatecase.admin")) {
             api.getUpdateChecker().getVersion().thenAcceptAsync(version -> {
                 if (version.isNew()) {
@@ -47,6 +49,11 @@ public class EventListener implements Subscriber {
                 }
             });
         }
+    }
+
+    @Subscribe
+    public void onPlayerLeave(LeaveEvent event) {
+        DCAPI.getInstance().getGUIManager().getMap().remove(event.player().getUniqueId());
     }
 
     @Subscribe

--- a/spigot/src/main/java/com/jodexindustries/donatecase/spigot/listener/EventListener.java
+++ b/spigot/src/main/java/com/jodexindustries/donatecase/spigot/listener/EventListener.java
@@ -49,6 +49,7 @@ public class EventListener implements Listener {
 
     @EventHandler
     public void onAdminJoined(PlayerJoinEvent event) {
+        DCAPI.getInstance().getGUIManager().getMap().remove(event.getPlayer().getUniqueId());
         backend.getAPI().getEventBus().post(new JoinEvent(BukkitUtils.fromBukkit(event.getPlayer())));
     }
 
@@ -125,6 +126,11 @@ public class EventListener implements Listener {
         InventoryHolder holder = e.getInventory().getHolder();
         if (!(holder instanceof BukkitInventory)) return;
 
+        DCAPI.getInstance().getGUIManager().getMap().remove(e.getPlayer().getUniqueId());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(org.bukkit.event.player.PlayerQuitEvent e) {
         DCAPI.getInstance().getGUIManager().getMap().remove(e.getPlayer().getUniqueId());
     }
 

--- a/spigot/src/main/java/com/jodexindustries/donatecase/spigot/listener/EventListener.java
+++ b/spigot/src/main/java/com/jodexindustries/donatecase/spigot/listener/EventListener.java
@@ -49,7 +49,6 @@ public class EventListener implements Listener {
 
     @EventHandler
     public void onAdminJoined(PlayerJoinEvent event) {
-        DCAPI.getInstance().getGUIManager().getMap().remove(event.getPlayer().getUniqueId());
         backend.getAPI().getEventBus().post(new JoinEvent(BukkitUtils.fromBukkit(event.getPlayer())));
     }
 
@@ -131,7 +130,7 @@ public class EventListener implements Listener {
 
     @EventHandler
     public void onPlayerQuit(org.bukkit.event.player.PlayerQuitEvent e) {
-        DCAPI.getInstance().getGUIManager().getMap().remove(e.getPlayer().getUniqueId());
+        backend.getAPI().getEventBus().post(new com.jodexindustries.donatecase.api.event.player.LeaveEvent(BukkitUtils.fromBukkit(e.getPlayer())));
     }
 
     @EventHandler


### PR DESCRIPTION
Players who disconnect or crash with an open case GUI would have their UUID stuck in GUIManager.playersGui map permanently, preventing them from ever opening cases again. Added cleanup on PlayerQuitEvent and PlayerJoinEvent as safety nets.